### PR TITLE
Tls 1.2 support

### DIFF
--- a/PluginCore.cs
+++ b/PluginCore.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+
 using Decal.Adapter;
 using MyClasses.MetaViewWrappers;
 

--- a/PluginCore.cs
+++ b/PluginCore.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-
+using System.Net;
 using Decal.Adapter;
 using MyClasses.MetaViewWrappers;
 
@@ -76,6 +76,7 @@ namespace TownCrier
         {
             try
             {
+                ServicePointManager.SecurityProtocol = SecurityProtocolTypeExtensions.Tls12;
                 MVWireupHelper.WireupStart(this, Host);
             }
             catch (Exception ex)

--- a/SSLProtocolExtensions.cs
+++ b/SSLProtocolExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+
+namespace System.Net {
+    using System.Security.Authentication;
+    public static class SecurityProtocolTypeExtensions {
+        public const SecurityProtocolType Tls12 = (SecurityProtocolType)SslProtocolsExtensions.Tls12;
+        public const SecurityProtocolType Tls11 = (SecurityProtocolType)SslProtocolsExtensions.Tls11;
+        public const SecurityProtocolType SystemDefault = (SecurityProtocolType)0;
+    }
+}
+
+namespace System.Security.Authentication {
+    public static class SslProtocolsExtensions {
+        public const SslProtocols Tls12 = (SslProtocols)0x00000C00;
+        public const SslProtocols Tls11 = (SslProtocols)0x00000300;
+    }
+}

--- a/SSLProtocolExtensions.cs
+++ b/SSLProtocolExtensions.cs
@@ -4,17 +4,21 @@ using System.Linq;
 using System.Text;
 
 
-namespace System.Net {
+namespace System.Net
+{
     using System.Security.Authentication;
-    public static class SecurityProtocolTypeExtensions {
+    public static class SecurityProtocolTypeExtensions
+    {
         public const SecurityProtocolType Tls12 = (SecurityProtocolType)SslProtocolsExtensions.Tls12;
         public const SecurityProtocolType Tls11 = (SecurityProtocolType)SslProtocolsExtensions.Tls11;
         public const SecurityProtocolType SystemDefault = (SecurityProtocolType)0;
     }
 }
 
-namespace System.Security.Authentication {
-    public static class SslProtocolsExtensions {
+namespace System.Security.Authentication
+{
+    public static class SslProtocolsExtensions
+    {
         public const SslProtocols Tls12 = (SslProtocols)0x00000C00;
         public const SslProtocols Tls11 = (SslProtocols)0x00000300;
     }

--- a/TownCrier.csproj
+++ b/TownCrier.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TownCrier</RootNamespace>
     <AssemblyName>TownCrier</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Decal.Adapter">
-      <HintPath>..\..\..\..\Program Files (x86)\Decal 3.0\Decal.Adapter.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Decal 3.0\Decal.Adapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Decal.Interop.Core, Version=2.9.7.5, Culture=neutral, PublicKeyToken=481f17d392f1fb65, processorArchitecture=MSIL">
@@ -78,6 +78,7 @@
     <Compile Include="Profile.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimedTrigger.cs" />
+    <Compile Include="SSLProtocolExtensions.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="VirindiViews\ViewSystemSelector.cs" />
     <Compile Include="VirindiViews\Wrapper.cs" />


### PR DESCRIPTION
Fixes discord webhooks by re-targeting to dotnet 3.5 and adding tls 1.2 protocol extensions.

(I updated Decal.Adapter reference hint path to be absolute, can change if its an issue...)